### PR TITLE
creates a documentation on the gh-pages branch after every commit automatically

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,35 @@
+name: Build and Deploy Documentation
+
+on:
+  push:
+    branches:
+      - main  # adjust the branch name if needed
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9.7  # adjust the Python version if needed
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r particle-analysis/docs/source/requirements.txt  # adjust the path if needed
+
+    - name: Build documentation
+      run: |
+        cd particle-analysis/docs
+        make clean && make html
+
+    - name: Deploy documentation
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: particle-analysis/docs/build/html  # adjust the path if needed

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -1,0 +1,1 @@
+particle


### PR DESCRIPTION
I think this needs to be done to make it work

1. Generate a personal access token on GitHub by going to Settings -> Developer settings -> Personal access tokens. Make sure to grant the token the necessary permissions for repository access.

2. Add the generated personal access token as a secret in your GitHub repository. Go to Settings -> Secrets -> New repository secret. Enter a name (e.g., ACTIONS_DEPLOY_KEY) and paste the personal access token value.