### PR TITLE
Refactor EventCharacteristics: allow both lattice and particle events

### DIFF
--- a/src/particle-analysis/EventCharacteristics.py
+++ b/src/particle-analysis/EventCharacteristics.py
@@ -1,5 +1,5 @@
 import numpy as np
-from ParticleClass import Particle
+from Particle import Particle
 from Lattice3D import Lattice3D
 
 class EventCharacteristics:
@@ -9,37 +9,53 @@ class EventCharacteristics:
 
     Parameters
     ----------
-    particle_data: list, numpy.ndarray
-        List or array containing particle objects for one event.
+    event_data: list, numpy.ndarray or Lattice3D
+        List or array containing particle objects for one event, or a lattice containing the relevant densities.
 
     Attributes
     ----------
-    particle_data_: list, numpy.ndarray
-        List or array containing particle objects for one event.
+    event_data_: list, numpy.ndarray or Lattice3D
+        List or array containing particle objects for one event, or a lattice containing the relevant densities.
+    has_lattice_: bool
+        Contains information if characteristics are derived from a lattice or particles
 
     Methods
     -------
+    set_event_data:
+        Overwrites the event data.
+    eccentricity:
+        Computes the spatial eccentricity.
     eccentricity_from_particles:
         Computes the spatial eccentricity from particles.
+    eccentricity_from_lattice:
+        Computes the spatial eccentricity from a 3D lattice.
     """
-    def __init__(self,particle_data):
-        # check that the input is a list/numpy.ndarray containing Particle objects
-        if not isinstance(particle_data, (list, np.ndarray)):
-            raise TypeError('The input is not a list nor a numpy.ndarray.')
-        for particle in particle_data:
-            if not isinstance(particle, Particle):
-                raise TypeError('At least one element in the input is not a ' +\
-                                'Particle type.')
-        self.particle_data_ = particle_data
+    def __init__(self, event_data):
+        self.set_event_data(event_data)
 
-    
+    def set_event_data (self, event_data):
+        # check if the input is a Lattice3D object
+        if isinstance(event_data, Lattice3D):
+            self.event_data_ = event_data
+            self.has_lattice_ = True
+        else:
+            # check that the input is a list/numpy.ndarray containing Particle objects
+            if not isinstance(event_data, (list, np.ndarray)):
+                raise TypeError('The input is not a list nor a numpy.ndarray.')
+            for particle in event_data:
+                if not isinstance(particle, Particle):
+                    raise TypeError('At least one element in the input is not a ' +
+                                    'Particle type.')
+            self.event_data_ = event_data
+            self.has_lattice_ = False
+            
     def eccentricity_from_particles(self,harmonic_n, weight_quantity = "energy"):
         real_eps=0
         imag_eps=0
         norm=0
         if harmonic_n < 1:
             raise ValueError("Eccentricity is only defined for positive expansion orders.")
-        for particle in particle_data:
+        for particle in self.event_data_:
             if weight_quantity == "energy":
                 weight = particle.E
             elif weight_quantity == "number":
@@ -63,25 +79,31 @@ class EventCharacteristics:
             norm += rn*weight
         return real_eps/norm + (imag_eps/norm)*1j
     
-    def eccentricity_from_lattice(self,harmonic_n,lattice):
+    def eccentricity_from_lattice(self,harmonic_n):
         real_eps=0
         imag_eps=0
         norm=0
         if harmonic_n < 1:
             raise ValueError("Eccentricity is only defined for positive expansion orders.")
-        for i, j, k in np.ndindex(lattice.grid_.shape):
-            x, y, z = lattice.get_coordinates(i, j, k)
+        for i, j, k in np.ndindex(self.event_data_.grid_.shape):
+            x, y, z = self.event_data_.get_coordinates(i, j, k)
             #Exception for dipole asymmetry
             if harmonic_n == 1:
                 rn = (x**2+y**2)**(3/2.0)
             else:
                 rn = (x**2+y**2)**(harmonic_n/2.0)
             t = np.arctan2(y,x)
-            lattice_density = lattice.get_value_by_index(i, j, k)
+            lattice_density = self.event_data_.get_value_by_index(i, j, k)
             real_eps += rn*np.cos(harmonic_n*t)*lattice_density
             imag_eps += rn*np.sin(harmonic_n*t)*lattice_density
             norm += rn*lattice_density
         return real_eps/norm + (imag_eps/norm)*1j
+    
+    def eccentricity(self,harmonic_n,weight_quantity = "energy"):
+        if self.has_lattice_:
+            return self.eccentricity_from_lattice(harmonic_n)
+        else:
+            return self.eccentricity_from_particles(harmonic_n, weight_quantity)
 
 #particle = Particle()
 #particle.t_=1.0
@@ -97,10 +119,12 @@ class EventCharacteristics:
 #part2.E_=2.0
 #particle_data=[part1,part2]
 #event=EventCharacteristics(particle_data)
-#print(event.eccentricity_from_particles(2))
+#print(event.eccentricity(2))
 #latt=Lattice3D(-2, 2, -2, 2, -2, 2, 50, 50, 50)
 #latt.add_particle_data(particle_data, 0.1, "energy density")
-#print(event.eccentricity_from_lattice(2,latt))
+#event2=EventCharacteristics(latt)
+#print(event2.eccentricity(2))
 #print(event.eccentricity_from_particles(2,"number"))
 #latt.add_particle_data(particle_data, 0.1, "number")
-#print(event.eccentricity_from_lattice(2,latt))
+#event2.set_event_data(latt)
+#print(event2.eccentricity_from_lattice(2))


### PR DESCRIPTION
I propose to structure EventCharacteristics in such a way that it can both deal with particle data and with lattice. The difference should be only under the hub.  The same could be done for the flow scripts, too.